### PR TITLE
Implement recording pipeline

### DIFF
--- a/Sources/CRUXX/Core/Model/ClimbingSession.swift
+++ b/Sources/CRUXX/Core/Model/ClimbingSession.swift
@@ -1,1 +1,32 @@
-// 등반 세션 모델 정의 파일
+import Foundation
+
+/// 등반 세션 모델을 나타냅니다.
+public struct ClimbingSession: Identifiable, Codable {
+    /// 세션 고유 식별자
+    public let id: UUID
+    /// 저장된 영상 파일 이름
+    public let fileName: String
+    /// 영상 파일이 저장된 경로
+    public let fileURL: URL
+    /// 세션 기록 시각
+    public let createdAt: Date
+
+    public init(id: UUID = UUID(), fileName: String, fileURL: URL, createdAt: Date = Date()) {
+        self.id = id
+        self.fileName = fileName
+        self.fileURL = fileURL
+        self.createdAt = createdAt
+    }
+}
+
+public extension ClimbingSession {
+    /// DTO 로부터 모델을 생성합니다.
+    init(dto: SessionDTO) {
+        self.init(id: dto.id, fileName: dto.fileName, fileURL: dto.fileURL, createdAt: dto.createdAt)
+    }
+
+    /// 모델을 DTO 로 변환합니다.
+    func toDTO() -> SessionDTO {
+        SessionDTO(id: id, fileName: fileName, fileURL: fileURL, createdAt: createdAt)
+    }
+}

--- a/Sources/CRUXX/Core/Service/CameraService.swift
+++ b/Sources/CRUXX/Core/Service/CameraService.swift
@@ -1,1 +1,154 @@
-// 카메라 제어 로직을 담은 서비스 파일
+import Foundation
+import AVFoundation
+import UIKit
+
+/// 카메라 및 녹화를 제어하는 서비스 프로토콜입니다.
+public protocol CameraServiceProtocol {
+    var previewLayer: AVCaptureVideoPreviewLayer { get }
+    func startCamera(completion: @escaping (Bool) -> Void)
+    func stopCamera()
+    func capturePhoto(completion: @escaping (UIImage?) -> Void)
+    func startRecording(completion: @escaping (Bool) -> Void)
+    func stopRecording(completion: @escaping (URL?) -> Void)
+}
+
+/// AVFoundation 기반 기본 카메라 서비스 구현체입니다.
+public final class CameraService: NSObject, CameraServiceProtocol {
+    public private(set) var previewLayer: AVCaptureVideoPreviewLayer
+
+    private let session = AVCaptureSession()
+    private let photoOutput = AVCapturePhotoOutput()
+    private let movieOutput = AVCaptureMovieFileOutput()
+    private let videoWriter: VideoWriterProtocol
+    private var recordingCompletion: ((URL?) -> Void)?
+    private let sessionQueue = DispatchQueue(label: "CameraService.Session")
+
+    public init(writer: VideoWriterProtocol = VideoWriter()) {
+        self.videoWriter = writer
+        self.previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        super.init()
+    }
+
+    public func startCamera(completion: @escaping (Bool) -> Void) {
+        checkPermission { [weak self] granted in
+            guard let self = self else { return }
+            guard granted else { completion(false); return }
+            self.sessionQueue.async {
+                self.configureSession()
+                self.session.startRunning()
+                DispatchQueue.main.async { completion(true) }
+            }
+        }
+    }
+
+    public func stopCamera() {
+        sessionQueue.async { [weak self] in
+            self?.session.stopRunning()
+        }
+    }
+
+    public func capturePhoto(completion: @escaping (UIImage?) -> Void) {
+        let settings = AVCapturePhotoSettings()
+        photoOutput.capturePhoto(with: settings, delegate: PhotoCaptureDelegate(completion: completion))
+    }
+
+    public func startRecording(completion: @escaping (Bool) -> Void) {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard !self.movieOutput.isRecording else { DispatchQueue.main.async { completion(false) }; return }
+            let url = self.videoWriter.startWriting()
+            self.movieOutput.startRecording(to: url, recordingDelegate: self)
+            DispatchQueue.main.async { completion(true) }
+        }
+    }
+
+    public func stopRecording(completion: @escaping (URL?) -> Void) {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.recordingCompletion = completion
+            if self.movieOutput.isRecording {
+                self.movieOutput.stopRecording()
+            } else {
+                DispatchQueue.main.async { completion(nil) }
+            }
+        }
+    }
+}
+
+private extension CameraService {
+    func configureSession() {
+        session.beginConfiguration()
+        defer { session.commitConfiguration() }
+
+        session.sessionPreset = .high
+
+        // 입력 설정
+        guard let videoDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+              let videoInput = try? AVCaptureDeviceInput(device: videoDevice),
+              session.canAddInput(videoInput) else { return }
+        session.addInput(videoInput)
+
+        if let audioDevice = AVCaptureDevice.default(for: .audio),
+           let audioInput = try? AVCaptureDeviceInput(device: audioDevice),
+           session.canAddInput(audioInput) {
+            session.addInput(audioInput)
+        }
+
+        // 출력 설정
+        if session.canAddOutput(photoOutput) {
+            session.addOutput(photoOutput)
+        }
+
+        if session.canAddOutput(movieOutput) {
+            session.addOutput(movieOutput)
+        }
+    }
+
+    func checkPermission(completion: @escaping (Bool) -> Void) {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            completion(true)
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                completion(granted)
+            }
+        default:
+            completion(false)
+        }
+    }
+}
+
+// MARK: - AVCaptureFileOutputRecordingDelegate
+extension CameraService: AVCaptureFileOutputRecordingDelegate {
+    public func fileOutput(_ output: AVCaptureFileOutput, didFinishRecordingTo outputFileURL: URL, from connections: [AVCaptureConnection], error: Error?) {
+        if let error = error {
+            print("녹화 중 오류 발생: \(error)")
+            DispatchQueue.main.async { [weak self] in self?.recordingCompletion?(nil) }
+        } else {
+            videoWriter.finishWriting { _ in }
+            DispatchQueue.main.async { [weak self] in self?.recordingCompletion?(outputFileURL) }
+        }
+        recordingCompletion = nil
+    }
+}
+
+private final class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
+    private let completion: (UIImage?) -> Void
+
+    init(completion: @escaping (UIImage?) -> Void) {
+        self.completion = completion
+    }
+
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        if let error = error {
+            print("사진 캡처 오류: \(error)")
+            completion(nil)
+            return
+        }
+        guard let data = photo.fileDataRepresentation(), let image = UIImage(data: data) else {
+            completion(nil)
+            return
+        }
+        completion(image)
+    }
+}

--- a/Sources/CRUXX/Core/Service/SessionManager.swift
+++ b/Sources/CRUXX/Core/Service/SessionManager.swift
@@ -1,1 +1,39 @@
-// 세션 저장과 로딩을 담당하는 매니저 파일
+import Foundation
+
+/// 세션 매니저 프로토콜입니다.
+public protocol SessionManagerProtocol {
+    func fetchSessions() -> [ClimbingSession]
+    func saveSession(_ session: ClimbingSession)
+    func deleteSession(_ session: ClimbingSession)
+    func updateSession(_ session: ClimbingSession)
+    func fetchSession(by id: UUID) -> ClimbingSession?
+}
+
+/// 세션 저장과 로딩을 담당하는 매니저 구현체입니다.
+public final class SessionManager: SessionManagerProtocol {
+    private let repository: SessionRepositoryProtocol
+
+    public init(repository: SessionRepositoryProtocol = SessionRepository()) {
+        self.repository = repository
+    }
+
+    public func fetchSessions() -> [ClimbingSession] {
+        repository.getSessions()
+    }
+
+    public func saveSession(_ session: ClimbingSession) {
+        repository.addSession(session)
+    }
+
+    public func deleteSession(_ session: ClimbingSession) {
+        repository.removeSession(session)
+    }
+
+    public func updateSession(_ session: ClimbingSession) {
+        repository.updateSession(session)
+    }
+
+    public func fetchSession(by id: UUID) -> ClimbingSession? {
+        repository.getSessions().first(where: { $0.id == id })
+    }
+}

--- a/Sources/CRUXX/Core/Service/VideoWriter.swift
+++ b/Sources/CRUXX/Core/Service/VideoWriter.swift
@@ -1,1 +1,30 @@
-// 영상 저장과 녹화 관리를 담당하는 파일
+import Foundation
+import AVFoundation
+
+/// 영상 저장을 담당하는 서비스 프로토콜입니다.
+public protocol VideoWriterProtocol {
+    func startWriting() -> URL
+    func appendFrame(_ sampleBuffer: CMSampleBuffer)
+    func finishWriting(completion: @escaping (URL?) -> Void)
+}
+
+/// AVCaptureMovieFileOutput을 활용한 기본 구현체입니다.
+public final class VideoWriter: NSObject, VideoWriterProtocol {
+    private var outputURL: URL?
+
+    public func startWriting() -> URL {
+        let fileName = "session-\(UUID().uuidString).mov"
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        outputURL = tempURL
+        return tempURL
+    }
+
+    public func appendFrame(_ sampleBuffer: CMSampleBuffer) {
+        // AVCaptureMovieFileOutput 사용 시 별도 프레임 처리는 필요 없습니다.
+    }
+
+    public func finishWriting(completion: @escaping (URL?) -> Void) {
+        completion(outputURL)
+        outputURL = nil
+    }
+}

--- a/Sources/CRUXX/Data/DTO/SessionDTO.swift
+++ b/Sources/CRUXX/Data/DTO/SessionDTO.swift
@@ -1,1 +1,13 @@
-// 세션 데이터 전송 객체 정의 파일
+import Foundation
+
+/// 세션 정보를 저장하기 위한 DTO 입니다.
+public struct SessionDTO: Codable {
+    /// 세션 식별자
+    public let id: UUID
+    /// 영상 파일 이름
+    public let fileName: String
+    /// 영상 파일 경로
+    public let fileURL: URL
+    /// 저장 시각
+    public let createdAt: Date
+}

--- a/Sources/CRUXX/Data/Repository/SessionRepository.swift
+++ b/Sources/CRUXX/Data/Repository/SessionRepository.swift
@@ -1,1 +1,57 @@
-// 세션 데이터 통합 관리용 저장소 파일
+import Foundation
+
+/// 세션 저장소 프로토콜입니다.
+public protocol SessionRepositoryProtocol {
+    func getSessions() -> [ClimbingSession]
+    func addSession(_ session: ClimbingSession)
+    func removeSession(_ session: ClimbingSession)
+    func updateSession(_ session: ClimbingSession)
+}
+
+/// 로컬 파일을 사용한 기본 세션 저장소 구현체입니다.
+public final class SessionRepository: SessionRepositoryProtocol {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        self.fileURL = documents.appendingPathComponent("sessions.json")
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            fileManager.createFile(atPath: fileURL.path, contents: nil)
+        }
+    }
+
+    public func getSessions() -> [ClimbingSession] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        let dtos = (try? JSONDecoder().decode([SessionDTO].self, from: data)) ?? []
+        return dtos.map { ClimbingSession(dto: $0) }
+    }
+
+    public func addSession(_ session: ClimbingSession) {
+        var sessions = getSessions()
+        sessions.append(session)
+        saveSessions(sessions)
+    }
+
+    public func removeSession(_ session: ClimbingSession) {
+        var sessions = getSessions()
+        sessions.removeAll { $0.id == session.id }
+        saveSessions(sessions)
+        try? fileManager.removeItem(at: session.fileURL)
+    }
+
+    public func updateSession(_ session: ClimbingSession) {
+        var sessions = getSessions()
+        if let index = sessions.firstIndex(where: { $0.id == session.id }) {
+            sessions[index] = session
+            saveSessions(sessions)
+        }
+    }
+
+    private func saveSessions(_ sessions: [ClimbingSession]) {
+        let dtos = sessions.map { $0.toDTO() }
+        guard let data = try? JSONEncoder().encode(dtos) else { return }
+        try? data.write(to: fileURL, options: [.atomic])
+    }
+}

--- a/Sources/CRUXX/Features/Recording/RecordingView.swift
+++ b/Sources/CRUXX/Features/Recording/RecordingView.swift
@@ -1,1 +1,74 @@
-// 영상 녹화 및 프리뷰 화면 UI 파일
+import SwiftUI
+import AVFoundation
+
+/// 카메라 프리뷰를 보여주는 뷰입니다.
+struct CameraPreviewView: UIViewRepresentable {
+    let previewLayer: AVCaptureVideoPreviewLayer
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        previewLayer.videoGravity = .resizeAspectFill
+        previewLayer.frame = view.bounds
+        view.layer.addSublayer(previewLayer)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        previewLayer.frame = uiView.bounds
+    }
+}
+
+/// 영상 녹화 및 프리뷰 화면입니다.
+public struct RecordingView: View {
+    @StateObject private var viewModel = RecordingViewModel()
+
+    public init() {}
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            CameraPreviewView(previewLayer: viewModel.cameraService.previewLayer)
+                .frame(maxWidth: .infinity, maxHeight: 300)
+                .background(Color.black)
+
+            Text(stateText)
+                .foregroundColor(.white)
+                .padding(8)
+                .background(Color.gray.opacity(0.7))
+                .cornerRadius(8)
+
+            Button(action: {
+                viewModel.toggleRecording()
+            }) {
+                Text(buttonTitle)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+            }
+        }
+        .padding()
+        .onAppear {
+            viewModel.cameraService.startCamera { success in
+                if !success {
+                    print("카메라 권한이 필요합니다.")
+                }
+            }
+        }
+        .onDisappear {
+            viewModel.cameraService.stopCamera()
+        }
+    }
+
+    private var buttonTitle: String {
+        viewModel.state == .recording ? "녹화 중지" : "녹화 시작"
+    }
+
+    private var stateText: String {
+        switch viewModel.state {
+        case .idle: return "대기 중"
+        case .recording: return "녹화 중"
+        case .stopped: return "녹화 완료"
+        }
+    }
+}

--- a/Sources/CRUXX/Features/Recording/RecordingViewModel.swift
+++ b/Sources/CRUXX/Features/Recording/RecordingViewModel.swift
@@ -1,1 +1,55 @@
-// 녹화 화면 상태와 이벤트 처리용 뷰모델 파일
+import Foundation
+import Combine
+
+/// 녹화 상태를 나타냅니다.
+public enum RecordingState {
+    case idle
+    case recording
+    case stopped
+}
+
+/// 녹화 화면 상태와 이벤트를 처리하는 뷰모델입니다.
+public final class RecordingViewModel: ObservableObject {
+    @Published public private(set) var state: RecordingState = .idle
+
+    public let cameraService: CameraServiceProtocol
+    private let sessionManager: SessionManagerProtocol
+
+    public init(cameraService: CameraServiceProtocol = CameraService(),
+                sessionManager: SessionManagerProtocol = SessionManager()) {
+        self.cameraService = cameraService
+        self.sessionManager = sessionManager
+    }
+
+    /// 녹화 시작 또는 중지를 토글합니다.
+    public func toggleRecording() {
+        switch state {
+        case .idle, .stopped:
+            startRecording()
+        case .recording:
+            stopRecording()
+        }
+    }
+
+    private func startRecording() {
+        cameraService.startRecording { [weak self] success in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.state = success ? .recording : .idle
+            }
+        }
+    }
+
+    private func stopRecording() {
+        cameraService.stopRecording { [weak self] url in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.state = .stopped
+            }
+            guard let url = url else { return }
+            let fileName = url.lastPathComponent
+            let session = ClimbingSession(fileName: fileName, fileURL: url)
+            self.sessionManager.saveSession(session)
+        }
+    }
+}

--- a/Sources/CRUXX/Features/Session/SessionListView.swift
+++ b/Sources/CRUXX/Features/Session/SessionListView.swift
@@ -1,1 +1,37 @@
-// 세션 리스트 화면 UI 파일
+import SwiftUI
+import AVKit
+
+/// 저장된 세션을 리스트로 보여주는 화면입니다.
+public struct SessionListView: View {
+    @StateObject private var viewModel = SessionListViewModel()
+
+    public init() {}
+
+    public var body: some View {
+        NavigationView {
+            List {
+                ForEach(viewModel.sessions) { session in
+                    NavigationLink(destination: VideoPlayer(player: AVPlayer(url: session.fileURL))) {
+                        HStack {
+                            Text(session.fileName)
+                            Spacer()
+                            Text(dateFormatter.string(from: session.createdAt))
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                    }
+                }
+                .onDelete(perform: viewModel.deleteSession)
+            }
+            .navigationTitle("세션 기록")
+            .onAppear { viewModel.loadSessions() }
+        }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateStyle = .short
+        df.timeStyle = .short
+        return df
+    }
+}

--- a/Sources/CRUXX/Features/Session/SessionListViewModel.swift
+++ b/Sources/CRUXX/Features/Session/SessionListViewModel.swift
@@ -1,1 +1,27 @@
-// 세션 리스트 데이터를 관리하는 뷰모델 파일
+import Foundation
+
+/// 세션 리스트 데이터를 관리하는 뷰모델입니다.
+public final class SessionListViewModel: ObservableObject {
+    @Published public private(set) var sessions: [ClimbingSession] = []
+
+    private let sessionManager: SessionManagerProtocol
+
+    public init(sessionManager: SessionManagerProtocol = SessionManager()) {
+        self.sessionManager = sessionManager
+        loadSessions()
+    }
+
+    /// 저장된 세션 목록을 다시 불러옵니다.
+    public func loadSessions() {
+        sessions = sessionManager.fetchSessions()
+    }
+
+    /// 세션을 삭제합니다.
+    public func deleteSession(at offsets: IndexSet) {
+        for index in offsets {
+            let session = sessions[index]
+            sessionManager.deleteSession(session)
+        }
+        loadSessions()
+    }
+}


### PR DESCRIPTION
## Summary
- add `ClimbingSession` model and conversion helpers
- implement `SessionDTO` and `SessionRepository` for local storage
- implement `SessionManager` service
- implement `CameraService` and `VideoWriter` using AVFoundation
- implement `RecordingView` and `RecordingViewModel`
- show saved sessions in `SessionListView`

## Testing
- `swift build` *(fails: no such module 'AVFoundation')*
- `swift test` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_6842bae1d74c833287fd01ee3171d5e5