### PR TITLE
fix orientation for recording

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -8,5 +8,13 @@
     <string>영상 녹음 기능 사용을 위해 마이크 접근이 필요합니다.</string>
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>녹화한 영상을 저장하기 위해 사진 보관함 접근이 필요합니다.</string>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
 </dict>
 </plist>

--- a/Sources/CRUXX/Core/Service/CameraService.swift
+++ b/Sources/CRUXX/Core/Service/CameraService.swift
@@ -42,6 +42,17 @@ public final class CameraService: NSObject, CameraServiceProtocol {
             self.sessionQueue.async {
                 self.configureSession()
                 self.session.startRunning()
+                if let connection = self.previewLayer.connection {
+                    if #available(iOS 17.0, *) {
+                        if connection.isVideoRotationAngleSupported(0) {
+                            connection.videoRotationAngle = 0
+                        }
+                    } else {
+                        if connection.isVideoOrientationSupported {
+                            connection.videoOrientation = .portrait
+                        }
+                    }
+                }
                 print("카메라 세션 시작")
                 DispatchQueue.main.async { completion(true) }
             }
@@ -72,22 +83,19 @@ public final class CameraService: NSObject, CameraServiceProtocol {
             let url = self.videoWriter.startWriting()
             self.currentOutputURL = url
             if let connection = self.movieOutput.connection(with: .video) {
-                let deviceOrientation = UIDevice.current.orientation
                 if #available(iOS 17.0, *) {
-                    let angle = Self.rotationAngle(for: deviceOrientation)
-                    if connection.isVideoRotationAngleSupported(angle) {
-                        connection.videoRotationAngle = angle
+                    if connection.isVideoRotationAngleSupported(0) {
+                        connection.videoRotationAngle = 0
                     }
                     if let previewConnection = self.previewLayer.connection,
-                       previewConnection.isVideoRotationAngleSupported(angle) {
-                        previewConnection.videoRotationAngle = angle
+                       previewConnection.isVideoRotationAngleSupported(0) {
+                        previewConnection.videoRotationAngle = 0
                     }
                 } else {
-                    let orientation = Self.videoOrientation(from: deviceOrientation)
                     if connection.isVideoOrientationSupported {
-                        connection.videoOrientation = orientation
+                        connection.videoOrientation = .portrait
                     }
-                    self.previewLayer.connection?.videoOrientation = orientation
+                    self.previewLayer.connection?.videoOrientation = .portrait
                 }
             }
             self.movieOutput.startRecording(to: url, recordingDelegate: self)


### PR DESCRIPTION
## Summary
- 녹화 시작 시 화면 방향이 바뀌지 않도록 고정
- 앱 전체를 세로 전용으로 설정

## Testing
- `swift test --enable-code-coverage` *(실패: SwiftUI 모듈 문제)*

------
https://chatgpt.com/codex/tasks/task_e_68451b9e8b5c833293a7f477e5918dcf