### PR TITLE
Fix session save

### DIFF
--- a/Sources/CRUXX/App/DIContainer.swift
+++ b/Sources/CRUXX/App/DIContainer.swift
@@ -6,8 +6,8 @@ public final class DIContainer: ObservableObject {
     public let cameraService: CameraServiceProtocol
 
     public init(sessionManager: SessionManagerProtocol = SessionManager(),
-                cameraService: CameraServiceProtocol = CameraService()) {
+                cameraService: CameraServiceProtocol? = nil) {
         self.sessionManager = sessionManager
-        self.cameraService = cameraService
+        self.cameraService = cameraService ?? CameraService(sessionManager: sessionManager)
     }
 }

--- a/Sources/CRUXX/Core/Service/CameraService.swift
+++ b/Sources/CRUXX/Core/Service/CameraService.swift
@@ -20,12 +20,15 @@ public final class CameraService: NSObject, CameraServiceProtocol {
     private let photoOutput = AVCapturePhotoOutput()
     private let movieOutput = AVCaptureMovieFileOutput()
     private let videoWriter: VideoWriterProtocol
+    private let sessionManager: SessionManagerProtocol
     private var recordingCompletion: ((URL?) -> Void)?
     private var currentOutputURL: URL?
     private let sessionQueue = DispatchQueue(label: "CameraService.Session")
 
-    public init(writer: VideoWriterProtocol = VideoWriter()) {
+    public init(writer: VideoWriterProtocol = VideoWriter(),
+                sessionManager: SessionManagerProtocol = SessionManager()) {
         self.videoWriter = writer
+        self.sessionManager = sessionManager
         self.previewLayer = AVCaptureVideoPreviewLayer(session: session)
         super.init()
     }
@@ -200,6 +203,9 @@ extension CameraService: AVCaptureFileOutputRecordingDelegate {
             DispatchQueue.main.async { [weak self] in self?.recordingCompletion?(nil) }
         } else {
             print("녹화 파일 저장 완료: \(outputFileURL.lastPathComponent)")
+            let fileName = outputFileURL.lastPathComponent
+            let session = ClimbingSession(fileName: fileName, fileURL: outputFileURL)
+            sessionManager.saveSession(session)
             DispatchQueue.main.async { [weak self] in self?.recordingCompletion?(outputFileURL) }
         }
         recordingCompletion = nil

--- a/Sources/CRUXX/Features/Recording/RecordingViewModel.swift
+++ b/Sources/CRUXX/Features/Recording/RecordingViewModel.swift
@@ -16,10 +16,10 @@ public final class RecordingViewModel: ObservableObject {
     public let cameraService: CameraServiceProtocol
     private let sessionManager: SessionManagerProtocol
 
-    public init(cameraService: CameraServiceProtocol = CameraService(),
+    public init(cameraService: CameraServiceProtocol? = nil,
                 sessionManager: SessionManagerProtocol = SessionManager()) {
-        self.cameraService = cameraService
         self.sessionManager = sessionManager
+        self.cameraService = cameraService ?? CameraService(sessionManager: sessionManager)
     }
 
     /// 녹화 시작 또는 중지를 토글합니다.


### PR DESCRIPTION
## Summary
- inject `SessionManager` into `CameraService`
- save new `ClimbingSession` when recording stops
- propagate dependency injection to `DIContainer` and `RecordingViewModel`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68466248a2948332b6ec2f8575ac9297