### PR TITLE
Fix orientation rotation

### DIFF
--- a/Sources/CRUXX/App/AppDelegate.swift
+++ b/Sources/CRUXX/App/AppDelegate.swift
@@ -1,0 +1,10 @@
+#if canImport(UIKit)
+import UIKit
+
+/// iOS 환경에서 전체 화면 방향을 세로로 고정하는 AppDelegate입니다.
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return .portrait
+    }
+}
+#endif

--- a/Sources/CRUXX/App/CruxxApp.swift
+++ b/Sources/CRUXX/App/CruxxApp.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// 앱의 시작점을 정의합니다.
 @main
 struct CruxxApp: App {
+    /// 세로 모드 고정을 위해 AppDelegate를 연결합니다.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var container = DIContainer()
 
     var body: some Scene {


### PR DESCRIPTION
## Summary
- prevent landscape orientation across the app using AppDelegate
- link the delegate in `CruxxApp` to enforce portrait mode

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6846631f1934833291d9d36a3222a887