### PR TITLE
Fix missing model imports

### DIFF
--- a/Sources/cruxxCore/Data/Repository/SessionRepository.swift
+++ b/Sources/cruxxCore/Data/Repository/SessionRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import cruxxModel
 
 /// 세션 저장소 프로토콜입니다.
 public protocol SessionRepositoryProtocol {

--- a/Sources/cruxxCore/Features/Main/MainViewModel.swift
+++ b/Sources/cruxxCore/Features/Main/MainViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import cruxxModel
 
 /// 메인 화면에서 필요한 데이터를 관리합니다.
 public final class MainViewModel: ObservableObject {

--- a/Sources/cruxxCore/Features/Recording/RecordingViewModel.swift
+++ b/Sources/cruxxCore/Features/Recording/RecordingViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import cruxxModel
 
 /// 녹화 상태를 나타냅니다.
 public enum RecordingState {

--- a/Sources/cruxxCore/Features/Session/SessionDetailViewModel.swift
+++ b/Sources/cruxxCore/Features/Session/SessionDetailViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVKit
+import cruxxModel
 
 /// 세션 상세 화면에서 영상을 재생하고 분석 결과를 제공하는 뷰모델입니다.
 public final class SessionDetailViewModel: ObservableObject {

--- a/Sources/cruxxCore/Features/Session/SessionListViewModel.swift
+++ b/Sources/cruxxCore/Features/Session/SessionListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import cruxxModel
 
 /// 세션 리스트 데이터를 관리하는 뷰모델입니다.
 public final class SessionListViewModel: ObservableObject {

--- a/Sources/cruxxCore/Service/SessionManager.swift
+++ b/Sources/cruxxCore/Service/SessionManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import cruxxModel
 
 /// 세션 매니저 프로토콜입니다.
 public protocol SessionManagerProtocol {


### PR DESCRIPTION
## Summary
- cruxxCore에서 ClimbingSession 등 모델 타입 사용 시 모델 모듈을 명시적으로 가져오도록 수정했습니다.

## Testing
- `swift test -v` *(실패: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_684674c5ad308332b609f8f88b29b332