### PR TITLE
Refactor RecordingViewModel for main actor

### DIFF
--- a/Sources/cruxxCore/Features/Recording/RecordingViewModel.swift
+++ b/Sources/cruxxCore/Features/Recording/RecordingViewModel.swift
@@ -10,6 +10,7 @@ public enum RecordingState {
 }
 
 /// 녹화 화면 상태와 이벤트를 처리하는 뷰모델입니다.
+@MainActor
 public final class RecordingViewModel: ObservableObject {
     @Published public private(set) var state: RecordingState = .idle
     @Published public var alertMessage: String?
@@ -38,14 +39,16 @@ public final class RecordingViewModel: ObservableObject {
         print("startRecording 호출")
         cameraService.startRecording { [weak self] success in
             guard let self = self else { return }
-            DispatchQueue.main.async {
-                if success {
-                    self.state = .recording
-                    print("녹화 시작됨")
-                } else {
-                    self.alertMessage = "녹화를 시작할 수 없습니다."
-                    self.state = .idle
-                    print("녹화 시작 실패")
+            Task {
+                await MainActor.run {
+                    if success {
+                        self.state = .recording
+                        print("녹화 시작됨")
+                    } else {
+                        self.alertMessage = "녹화를 시작할 수 없습니다."
+                        self.state = .idle
+                        print("녹화 시작 실패")
+                    }
                 }
             }
         }
@@ -55,19 +58,21 @@ public final class RecordingViewModel: ObservableObject {
         print("stopRecording 호출")
         cameraService.stopRecording { [weak self] url in
             guard let self = self else { return }
-            DispatchQueue.main.async {
-                self.state = .stopped
-                print("녹화 중지 완료")
+            Task {
+                await MainActor.run {
+                    self.state = .stopped
+                    print("녹화 중지 완료")
+                }
+                guard let url = url else {
+                    await MainActor.run { self.alertMessage = "영상 저장에 실패했습니다." }
+                    print("저장 실패")
+                    return
+                }
+                print("저장된 파일명: \(url.lastPathComponent)")
+                let fileName = url.lastPathComponent
+                let session = ClimbingSession(fileName: fileName, fileURL: url)
+                self.sessionManager.saveSession(session)
             }
-            guard let url = url else {
-                self.alertMessage = "영상 저장에 실패했습니다."
-                print("저장 실패")
-                return
-            }
-            print("저장된 파일명: \(url.lastPathComponent)")
-            let fileName = url.lastPathComponent
-            let session = ClimbingSession(fileName: fileName, fileURL: url)
-            self.sessionManager.saveSession(session)
         }
     }
 }

--- a/Tests/cruxxCoreTests/UnitTests/RecordingViewModelTests.swift
+++ b/Tests/cruxxCoreTests/UnitTests/RecordingViewModelTests.swift
@@ -3,11 +3,13 @@ import XCTest
 
 final class RecordingViewModelTests: XCTestCase {
     /// 녹화 시작 시 상태가 변경되고 서비스가 호출되는지 확인합니다.
-    func test녹화시작시상태변경() {
+    @MainActor
+    func test녹화시작시상태변경() async throws {
         let camera = MockCameraService()
         let manager = MockSessionManager()
         let vm = RecordingViewModel(cameraService: camera, sessionManager: manager)
         vm.toggleRecording()
+        try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertEqual(vm.state, .recording)
         XCTAssertTrue(camera.didStartRecording)
     }


### PR DESCRIPTION
## Summary
- resolve data race by isolating `RecordingViewModel` on `MainActor`
- update async handling in `startRecording` and `stopRecording`
- adjust unit test for concurrency

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68467cc871ec833299304907a04422c5