### PR TITLE
Fix test names for SwiftPM

### DIFF
--- a/Tests/cruxxCoreTests/Recording/RecordingViewModelTests.swift
+++ b/Tests/cruxxCoreTests/Recording/RecordingViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class RecordingViewModelTests: XCTestCase {
     /// 녹화 시작 시 상태가 변경되고 서비스가 호출되는지 확인합니다.
     @MainActor
-    func test녹화시작시상태변경() async throws {
+    func testStartRecordingChangesState() async throws {
         let camera = MockCameraService()
         let manager = MockSessionManager()
         let vm = RecordingViewModel(cameraService: camera, sessionManager: manager)

--- a/Tests/cruxxCoreTests/Session/MainViewModelTests.swift
+++ b/Tests/cruxxCoreTests/Session/MainViewModelTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class MainViewModelTests: XCTestCase {
     /// 최근 세션이 3개까지 정렬되어 로드되는지 확인합니다.
-    func test대시보드로드시최근3개세션정렬() {
+    func testDashboardLoadsSortedRecentSessions() {
         let repo = MockSessionRepository()
         let manager = SessionManager(repository: repo)
         let now = Date()

--- a/Tests/cruxxCoreTests/Session/SessionListViewModelTests.swift
+++ b/Tests/cruxxCoreTests/Session/SessionListViewModelTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class SessionListViewModelTests: XCTestCase {
     /// 삭제 기능 동작 시 세션이 제거되는지 확인합니다.
-    func test삭제후세션리스트갱신() {
+    func testDeleteUpdatesSessionList() {
         let repo = MockSessionRepository()
         let manager = SessionManager(repository: repo)
         let session = ClimbingSession(fileName: "a.mov", fileURL: URL(fileURLWithPath: "a.mov"))

--- a/Tests/cruxxCoreTests/Session/SessionManagerTests.swift
+++ b/Tests/cruxxCoreTests/Session/SessionManagerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class SessionManagerTests: XCTestCase {
     /// 세션을 저장하고 불러올 수 있는지 확인합니다.
-    func test세션저장후조회() {
+    func testSaveAndFetchSession() {
         let repo = MockSessionRepository()
         let manager = SessionManager(repository: repo)
         let session = ClimbingSession(fileName: "test.mov", fileURL: URL(fileURLWithPath: "test.mov"))

--- a/Tests/cruxxCoreTests/Settings/SettingsViewModelTests.swift
+++ b/Tests/cruxxCoreTests/Settings/SettingsViewModelTests.swift
@@ -4,7 +4,8 @@ import XCTest
 @testable import cruxxCore
 
 final class SettingsViewModelTests: XCTestCase {
-    func test알림설정변경시저장됨() {
+    /// 알림 설정 변경 시 값이 저장되는지 확인합니다.
+    func testNotificationSettingPersistence() {
         // 변경 후 값이 UserDefaults에 반영되는지 확인합니다.
         let vm = SettingsViewModel()
         vm.notificationsEnabled = true


### PR DESCRIPTION
## Summary
- 테스트 함수명을 한글에서 영문으로 수정하여 SwiftPM 인식 문제 해결

## Testing
- `swift test -l` 실행 시 `no such module 'Combine'` 오류 발생
- `swift test` 실행 시 동일한 오류 발생

------
https://chatgpt.com/codex/tasks/task_e_684681a8804883328d1b3733da547040