### PR TITLE
Fix missing imports & update iOS target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "cruxx",
     platforms: [
-        .iOS(.v15),
+        .iOS(.v16),
         .macOS(.v10_15)
     ],
     products: [

--- a/Sources/cruxxApp/App/CameraService.swift
+++ b/Sources/cruxxApp/App/CameraService.swift
@@ -1,6 +1,8 @@
 import Foundation
 import AVFoundation
 import UIKit
+import cruxxCore
+import cruxxModel
 
 /// AVFoundation 기반 기본 카메라 서비스 구현체입니다.
 public final class CameraService: NSObject, CameraServiceProtocol {

--- a/Sources/cruxxApp/App/DIContainer.swift
+++ b/Sources/cruxxApp/App/DIContainer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import cruxxCore
 
 /// 앱 전역에서 사용되는 서비스 인스턴스를 보관합니다.
 public final class DIContainer: ObservableObject {

--- a/Sources/cruxxApp/Features/Main/MainView.swift
+++ b/Sources/cruxxApp/Features/Main/MainView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import cruxxCore
+import cruxxModel
 
 /// 최근 세션 요약과 간단한 통계를 보여주는 메인 화면입니다.
 public struct MainView: View {

--- a/Sources/cruxxApp/Features/Recording/RecordingView.swift
+++ b/Sources/cruxxApp/Features/Recording/RecordingView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import cruxxCore
 
 /// 카메라 프리뷰를 보여주는 뷰입니다.
 struct CameraPreviewView: UIViewRepresentable {

--- a/Sources/cruxxApp/Features/Session/SessionDetailView.swift
+++ b/Sources/cruxxApp/Features/Session/SessionDetailView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import AVKit
+import cruxxCore
+import cruxxModel
 
 /// 단일 세션 영상을 재생하고 분석 정보를 표시합니다.
 public struct SessionDetailView: View {

--- a/Sources/cruxxApp/Features/Session/SessionListView.swift
+++ b/Sources/cruxxApp/Features/Session/SessionListView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import AVKit
+import cruxxCore
+import cruxxModel
 
 /// 저장된 세션을 리스트로 보여주는 화면입니다.
 public struct SessionListView: View {

--- a/Sources/cruxxApp/Features/Settings/SettingsView.swift
+++ b/Sources/cruxxApp/Features/Settings/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import cruxxCore
 
 /// 앱 기본 설정을 보여주는 화면입니다.
 public struct SettingsView: View {


### PR DESCRIPTION
## Summary
- import required modules in cruxxApp
- bump iOS deployment target to 16

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_684686e70d788332baf6401747825db8