### PR TITLE
Fix CameraService Sendable completion

### DIFF
--- a/PROTOCOLS.md
+++ b/PROTOCOLS.md
@@ -29,7 +29,7 @@ protocol SessionManagerProtocol { func fetchSessions() -> [ClimbingSession] // �
 
 **2. 영상 녹화/카메라 제어**
 
-protocol CameraServiceProtocol { func startCamera(completion: @escaping (Bool) -> Void) // 카메라 시작 func stopCamera() // 카메라 종료 func capturePhoto(completion: @escaping (Data?) -> Void) // 사진 데이터 캡처 func startRecording(completion: @escaping (Bool) -> Void) // 영상 녹화 시작 func stopRecording(completion: @escaping (URL?) -> Void) // 영상 녹화 종료, 파일 URL 반환 }
+protocol CameraServiceProtocol { func startCamera(completion: @escaping (Bool) -> Void) // 카메라 시작 func stopCamera() // 카메라 종료 func capturePhoto(completion: @escaping (Data?) -> Void) // 사진 데이터 캡처 func startRecording(completion: @escaping (Bool) -> Void) // 영상 녹화 시작 func stopRecording(completion: @Sendable @escaping (URL?) -> Void) // 영상 녹화 종료, 파일 URL 반환 }
 
 ---
 

--- a/Sources/cruxxApp/App/CameraService.swift
+++ b/Sources/cruxxApp/App/CameraService.swift
@@ -82,12 +82,12 @@ public final class CameraService: NSObject, CameraServiceProtocol {
         }
     }
 
-    public func stopRecording(completion: @escaping (URL?) -> Void) {
+    public func stopRecording(completion: @Sendable @escaping (URL?) -> Void) {
         print("녹화 중지 요청")
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
             self.isRecording = false
-            self.videoWriter.finishWriting { [weak self] url in
+            self.videoWriter.finishWriting { [weak self] (url: URL?) -> Void in
                 guard let self = self else { return }
                 DispatchQueue.main.async {
                     completion(url)

--- a/Sources/cruxxCore/Features/Recording/RecordingViewModel.swift
+++ b/Sources/cruxxCore/Features/Recording/RecordingViewModel.swift
@@ -56,7 +56,7 @@ public final class RecordingViewModel: ObservableObject {
 
     private func stopRecording() {
         print("stopRecording 호출")
-        cameraService.stopRecording { [weak self] url in
+        cameraService.stopRecording { [weak self] (url: URL?) -> Void in
             guard let self = self else { return }
             Task {
                 await MainActor.run {

--- a/Sources/cruxxCore/Service/CameraServiceProtocol.swift
+++ b/Sources/cruxxCore/Service/CameraServiceProtocol.swift
@@ -8,5 +8,5 @@ public protocol CameraServiceProtocol {
     func stopCamera()
     func capturePhoto(completion: @escaping (Data?) -> Void)
     func startRecording(completion: @escaping (Bool) -> Void)
-    func stopRecording(completion: @escaping (URL?) -> Void)
+    func stopRecording(completion: @Sendable @escaping (URL?) -> Void)
 }

--- a/Tests/cruxxCoreTests/Mocks/MockObjects.swift
+++ b/Tests/cruxxCoreTests/Mocks/MockObjects.swift
@@ -39,7 +39,7 @@ final class MockCameraService: CameraServiceProtocol {
         didStartRecording = true
         completion(true)
     }
-    func stopRecording(completion: @escaping (URL?) -> Void) {
+    func stopRecording(completion: @Sendable @escaping (URL?) -> Void) {
         didStopRecording = true
         completion(recordingURL)
     }


### PR DESCRIPTION
## Summary
- `CameraService.stopRecording`의 completion 파라미터를 `@Sendable`로 변경
- 프로토콜 및 목 객체 시그니처를 동일하게 수정
- 녹화 중지 시점 클로저에 명시적 타입을 부여하여 동시성 검사 오류 방지
- 관련 문서(PROTOCOLS.md) 갱신

## Testing
- `swift build` *(실패: Combine 모듈 미존재)*
- `swift test` *(실패: Combine 모듈 미존재)*

------
https://chatgpt.com/codex/tasks/task_e_68468895b93c8332a08860ab11fcdc49