### PR TITLE
Fix ViewModel MainActor usage

### DIFF
--- a/Sources/cruxxApp/App/AppRouter.swift
+++ b/Sources/cruxxApp/App/AppRouter.swift
@@ -9,7 +9,7 @@ public struct AppRouter: View {
 
     public var body: some View {
         TabView {
-            MainView()
+            MainView(container: container)
                 .tabItem {
                     Label("홈", systemImage: "house.fill")
                 }
@@ -19,7 +19,7 @@ public struct AppRouter: View {
                     Label("녹화", systemImage: "video.circle")
                 }
 
-            SessionListView()
+            SessionListView(container: container)
                 .tabItem {
                     Label("세션", systemImage: "list.bullet")
                 }

--- a/Sources/cruxxApp/App/CameraService.swift
+++ b/Sources/cruxxApp/App/CameraService.swift
@@ -95,7 +95,7 @@ public final class CameraService: NSObject, CameraServiceProtocol {
                 }
                 if let url = url {
                     let session = ClimbingSession(fileName: url.lastPathComponent, fileURL: url)
-                    self.sessionManager.saveSession(session)
+                    Task { await self.sessionManager.saveSession(session) }
                 }
                 self.currentOutputURL = nil
             }

--- a/Sources/cruxxApp/Features/Main/MainView.swift
+++ b/Sources/cruxxApp/Features/Main/MainView.swift
@@ -5,9 +5,11 @@ import cruxxModel
 
 /// 최근 세션 요약과 간단한 통계를 보여주는 메인 화면입니다.
 public struct MainView: View {
-    @StateObject private var viewModel = MainViewModel()
+    @StateObject private var viewModel: MainViewModel
 
-    public init() {}
+    public init(container: DIContainer) {
+        _viewModel = StateObject(wrappedValue: MainViewModel(sessionManager: container.sessionManager))
+    }
 
     public var body: some View {
         NavigationView {
@@ -55,7 +57,7 @@ public struct MainView: View {
 #if DEBUG
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView()
+        MainView(container: DIContainer())
     }
 }
 #endif

--- a/Sources/cruxxApp/Features/Session/SessionListView.swift
+++ b/Sources/cruxxApp/Features/Session/SessionListView.swift
@@ -6,9 +6,11 @@ import cruxxModel
 
 /// 저장된 세션을 리스트로 보여주는 화면입니다.
 public struct SessionListView: View {
-    @StateObject private var viewModel = SessionListViewModel()
+    @StateObject private var viewModel: SessionListViewModel
 
-    public init() {}
+    public init(container: DIContainer) {
+        _viewModel = StateObject(wrappedValue: SessionListViewModel(sessionManager: container.sessionManager))
+    }
 
     public var body: some View {
         NavigationView {
@@ -47,7 +49,7 @@ public struct SessionListView: View {
 #if DEBUG
 struct SessionListView_Previews: PreviewProvider {
     static var previews: some View {
-        SessionListView()
+        SessionListView(container: DIContainer())
     }
 }
 #endif

--- a/Sources/cruxxCore/Features/Main/MainViewModel.swift
+++ b/Sources/cruxxCore/Features/Main/MainViewModel.swift
@@ -2,13 +2,14 @@ import Foundation
 import cruxxModel
 
 /// 메인 화면에서 필요한 데이터를 관리합니다.
+@MainActor
 public final class MainViewModel: ObservableObject {
     @Published public private(set) var recentSessions: [ClimbingSession] = []
     @Published public private(set) var totalCount: Int = 0
 
     private let sessionManager: SessionManagerProtocol
 
-    public init(sessionManager: SessionManagerProtocol = SessionManager()) {
+    public init(sessionManager: SessionManagerProtocol) {
         self.sessionManager = sessionManager
     }
 

--- a/Sources/cruxxCore/Features/Session/SessionListViewModel.swift
+++ b/Sources/cruxxCore/Features/Session/SessionListViewModel.swift
@@ -2,12 +2,13 @@ import Foundation
 import cruxxModel
 
 /// 세션 리스트 데이터를 관리하는 뷰모델입니다.
+@MainActor
 public final class SessionListViewModel: ObservableObject {
     @Published public private(set) var sessions: [ClimbingSession] = []
 
     private let sessionManager: SessionManagerProtocol
 
-    public init(sessionManager: SessionManagerProtocol = SessionManager()) {
+    public init(sessionManager: SessionManagerProtocol) {
         self.sessionManager = sessionManager
         loadSessions()
     }


### PR DESCRIPTION
## Summary
- remove default SessionManager creation in view models
- mark MainViewModel and SessionListViewModel with `@MainActor`
- inject DIContainer dependencies to views
- ensure session save occurs on MainActor

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68468c07cecc8332bcaaabddff4a14c2