### PR TITLE
Update recording navigation flow

### DIFF
--- a/cruxx/App/ContentView.swift
+++ b/cruxx/App/ContentView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var showRecordingView = false
+
     init() {
         UITabBar.appearance().backgroundColor = .clear
     }
@@ -20,15 +22,18 @@ struct ContentView: View {
                 .ignoresSafeArea()
 
             TabView {
-                Text("Home")
-                    .tabItem {
-                        Label("Home", systemImage: "house")
+                VStack {
+                    Spacer()
+                    Button("Start Recording") {
+                        showRecordingView = true
                     }
-
-                RecordingView()
-                    .tabItem {
-                        Label("Record", systemImage: "camera")
-                    }
+                    .font(.title2)
+                    .padding()
+                    Spacer()
+                }
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
 
                 Text("Sessions")
                     .tabItem {
@@ -39,6 +44,9 @@ struct ContentView: View {
                     .tabItem {
                         Label("Settings", systemImage: "gearshape")
                     }
+            }
+            .fullScreenCover(isPresented: $showRecordingView) {
+                RecordingView()
             }
             .padding(.bottom, 24)
             .background(

--- a/cruxx/App/Features/Recording/RecordingView.swift
+++ b/cruxx/App/Features/Recording/RecordingView.swift
@@ -6,35 +6,22 @@ struct RecordingView: View {
     @StateObject private var viewModel = RecordingViewModel()
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .bottom) {
             CameraPreviewView(layer: viewModel.previewLayer)
                 .ignoresSafeArea()
 
-            VStack {
-                Spacer()
-
-                VStack(spacing: 16) {
-                    Text(viewModel.isRecording ? "Recording..." : "Ready")
-                        .font(.headline)
-                        .foregroundColor(.white)
-
-                    Button(action: {
-                        if viewModel.isRecording {
-                            viewModel.stopRecording()
-                        } else {
-                            viewModel.startRecording()
-                        }
-                    }) {
-                        Circle()
-                            .fill(viewModel.isRecording ? Color.gray : Color.red)
-                            .frame(width: 70, height: 70)
-                    }
+            Button(action: {
+                if viewModel.isRecording {
+                    viewModel.stopRecording()
+                } else {
+                    viewModel.startRecording()
                 }
-                .padding(24)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 25))
-                .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 5)
-                .padding(.bottom, 32)
+            }) {
+                Circle()
+                    .fill(viewModel.isRecording ? Color.gray : Color.red)
+                    .frame(width: 80, height: 80)
             }
+            .padding(.bottom, 40)
         }
     }
 }


### PR DESCRIPTION
## Summary
- start recording from Home tab via fullscreen cover
- simplify RecordingView layout for fullscreen camera preview

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68515bdc08c08332bd45fdd54913cf63