### PR TITLE
Improve recording UX

### DIFF
--- a/cruxx/App/Features/Recording/RecordingView.swift
+++ b/cruxx/App/Features/Recording/RecordingView.swift
@@ -4,24 +4,68 @@ import AVFoundation
 /// 라이브 카메라 프리뷰와 녹화 버튼을 제공하는 화면입니다.
 struct RecordingView: View {
     @StateObject private var viewModel = RecordingViewModel()
+    @State private var countdown: Int?
+    @State private var countdownTimer: Timer?
+    @State private var blink = false
 
     var body: some View {
         ZStack(alignment: .bottom) {
             CameraPreviewView(session: viewModel.session)
                 .ignoresSafeArea()
 
-            Button(action: {
-                if viewModel.isRecording {
-                    viewModel.stopRecording()
-                } else {
-                    viewModel.startRecording()
-                }
-            }) {
-                Circle()
-                    .fill(viewModel.isRecording ? Color.gray : Color.red)
-                    .frame(width: 80, height: 80)
+            if let remaining = countdown {
+                Text("\(remaining)")
+                    .font(.system(size: 60, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(40)
+                    .background(Color.black.opacity(0.5))
+                    .clipShape(Circle())
             }
-            .padding(.bottom, 40)
+
+            VStack {
+                if viewModel.isRecording {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(Color.red)
+                            .frame(width: 12, height: 12)
+                            .opacity(blink ? 0.2 : 1)
+                            .animation(.easeInOut(duration: 0.8).repeatForever(), value: blink)
+                            .onAppear { blink.toggle() }
+
+                        Text("REC \(timeString(from: viewModel.elapsedTime))")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                    }
+                    .padding(.top, 16)
+                    .frame(maxWidth: .infinity, alignment: .top)
+                }
+
+                Spacer()
+
+                if viewModel.showSaveMessage {
+                    Text("Recording saved!")
+                        .padding(8)
+                        .background(Color.black.opacity(0.6))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .transition(.opacity)
+                        .padding(.bottom, 80)
+                }
+
+                Button(action: {
+                    if viewModel.isRecording {
+                        viewModel.stopRecording()
+                    } else if countdown == nil {
+                        startCountdown()
+                    }
+                }) {
+                    Circle()
+                        .fill(viewModel.isRecording ? Color.gray : Color.red)
+                        .frame(width: 80, height: 80)
+                }
+                .disabled(countdown != nil)
+                .padding(.bottom, 40)
+            }
         }
         .onAppear {
             viewModel.startSession()
@@ -29,6 +73,27 @@ struct RecordingView: View {
         .onDisappear {
             viewModel.stopSession()
         }
+    }
+
+    private func startCountdown() {
+        countdown = 3
+        countdownTimer?.invalidate()
+        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            guard let current = countdown else { return }
+            if current > 1 {
+                countdown = current - 1
+            } else {
+                timer.invalidate()
+                countdown = nil
+                viewModel.startRecording()
+            }
+        }
+    }
+
+    private func timeString(from time: TimeInterval) -> String {
+        let minutes = Int(time) / 60
+        let seconds = Int(time) % 60
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 }
 

--- a/cruxx/Core/Recording/RecordingViewModel.swift
+++ b/cruxx/Core/Recording/RecordingViewModel.swift
@@ -1,11 +1,55 @@
 import Foundation
 import AVFoundation
+import UIKit
 
 /// 녹화 상태와 액션을 관리하는 뷰모델입니다.
 @MainActor
 final class RecordingViewModel: ObservableObject {
     @Published private(set) var isRecording: Bool = false
+    @Published var elapsedTime: TimeInterval = 0
+    @Published var showSaveMessage: Bool = false
     private let recordingManager = RecordingManager()
+    private var elapsedTimer: Timer?
+    private var backgroundObserver: NSObjectProtocol?
+
+    struct ClimbingSession {
+        let filename: String
+        let date: Date
+        let fileURL: URL
+    }
+
+    init() {
+        backgroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.willResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            if self.isRecording {
+                self.stopRecording()
+            }
+        }
+    }
+
+    deinit {
+        if let observer = backgroundObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func startElapsedTimer() {
+        elapsedTime = 0
+        elapsedTimer?.invalidate()
+        elapsedTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.elapsedTime += 1
+        }
+    }
+
+    private func stopElapsedTimer() {
+        elapsedTimer?.invalidate()
+        elapsedTimer = nil
+    }
 
     var session: AVCaptureSession {
         recordingManager.session
@@ -29,12 +73,22 @@ final class RecordingViewModel: ObservableObject {
     func startRecording() {
         recordingManager.startRecording()
         isRecording = true
+        startElapsedTimer()
     }
 
     /// 녹화를 종료합니다.
     func stopRecording() {
         recordingManager.stopRecording { [weak self] in
-            self?.isRecording = false
+            guard let self else { return }
+            self.isRecording = false
+            self.stopElapsedTimer()
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("cruxx_temp.mov")
+            let session = ClimbingSession(filename: url.lastPathComponent, date: Date(), fileURL: url)
+            print("Saved session: \(session)")
+            self.showSaveMessage = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                self?.showSaveMessage = false
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- show countdown timer before recording
- display blinking recording indicator and elapsed time
- stop recording when app goes to background
- show toast after saving video and log session info

## Testing
- `swiftc -parse cruxx/App/Features/Recording/RecordingView.swift cruxx/Core/Recording/RecordingViewModel.swift`

------
https://chatgpt.com/codex/tasks/task_e_6851702e9950833281f0249762521af4