### PR TITLE
Add session list view

### DIFF
--- a/cruxx/App/ContentView.swift
+++ b/cruxx/App/ContentView.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
                     Label("Home", systemImage: "house")
                 }
 
-                Text("Sessions")
+                SessionListView()
                     .tabItem {
                         Label("Sessions", systemImage: "list.bullet")
                     }

--- a/cruxx/App/Features/Session/SessionListView.swift
+++ b/cruxx/App/Features/Session/SessionListView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// 저장된 세션 영상을 카드 형태로 나열하는 화면입니다.
+struct SessionListView: View {
+    @StateObject private var viewModel = SessionListViewModel()
+    private let columns = [
+        GridItem(.flexible(), spacing: 16),
+        GridItem(.flexible())
+    ]
+
+    var body: some View {
+        ScrollView {
+            if viewModel.sessions.isEmpty {
+                Text("No sessions saved yet.")
+                    .foregroundColor(.white.opacity(0.7))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(viewModel.sessions) { session in
+                        SessionCard(session: session)
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}
+
+private struct SessionCard: View {
+    let session: SessionListViewModel.ClimbingSession
+    private let randomHeight: CGFloat = .random(in: 180...260)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Rectangle()
+                .fill(Color.gray.opacity(0.3))
+                .frame(height: randomHeight)
+                .overlay(
+                    Image(systemName: "video")
+                        .font(.system(size: 30))
+                        .foregroundColor(.white.opacity(0.8))
+                )
+            Text(session.filename)
+                .font(.headline)
+                .foregroundColor(.white)
+                .lineLimit(1)
+            Text(dateString(from: session.date))
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.7))
+        }
+        .padding(12)
+        .background(
+            .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: 20)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Color.white.opacity(0.15), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.25), radius: 10, x: 0, y: 4)
+    }
+
+    private func dateString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+#Preview {
+    SessionListView()
+}
+

--- a/cruxx/Core/Session/SessionListViewModel.swift
+++ b/cruxx/Core/Session/SessionListViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftUI
+
+/// 저장된 세션 목록을 관리하는 뷰모델입니다.
+@MainActor
+final class SessionListViewModel: ObservableObject {
+    /// 등반 세션 데이터 구조입니다.
+    struct ClimbingSession: Identifiable {
+        let id = UUID()
+        let filename: String
+        let date: Date
+        let fileURL: URL
+    }
+
+    @Published private(set) var sessions: [ClimbingSession] = []
+
+    init() {
+        loadMockSessions()
+    }
+
+    /// 임시 목업 세션 데이터를 생성합니다.
+    private func loadMockSessions() {
+        let baseURL = FileManager.default.temporaryDirectory
+        sessions = (1...10).map { index in
+            let filename = "session_\(index).mov"
+            return ClimbingSession(
+                filename: filename,
+                date: Calendar.current.date(byAdding: .day, value: -index, to: Date()) ?? Date(),
+                fileURL: baseURL.appendingPathComponent(filename)
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- show saved sessions in a waterfall grid
- manage sessions with mock data in view model
- connect SessionListView to the tab bar

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68517b06edcc8332b95113367c97840a