### PR TITLE
Add Core Data session persistence

### DIFF
--- a/cruxx/App/Features/Session/SessionListView.swift
+++ b/cruxx/App/Features/Session/SessionListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Foundation
 
 /// 저장된 세션 영상을 카드 형태로 나열하는 화면입니다.
 struct SessionListView: View {
@@ -27,7 +28,7 @@ struct SessionListView: View {
 }
 
 private struct SessionCard: View {
-    let session: SessionListViewModel.ClimbingSession
+    let session: ClimbingSession
     private let randomHeight: CGFloat = .random(in: 180...260)
 
     var body: some View {

--- a/cruxx/Core/Persistence/PersistenceController.swift
+++ b/cruxx/Core/Persistence/PersistenceController.swift
@@ -1,0 +1,38 @@
+import CoreData
+
+/// Core Data 스택을 관리하는 컨트롤러입니다.
+final class PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+    let backgroundContext: NSManagedObjectContext
+
+    /// 메인 쓰레드에서 사용되는 컨텍스트입니다.
+    var viewContext: NSManagedObjectContext { container.viewContext }
+
+    private init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "cruxx")
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores { _, error in
+            if let error {
+                fatalError("Persistent store 로드 실패: \(error)")
+            }
+        }
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        backgroundContext = container.newBackgroundContext()
+    }
+
+    /// 변경 사항을 저장합니다.
+    func saveContext() {
+        let context = container.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                print("컨텍스트 저장 실패: \(error)")
+            }
+        }
+    }
+}

--- a/cruxx/Core/Recording/RecordingManager.swift
+++ b/cruxx/Core/Recording/RecordingManager.swift
@@ -131,10 +131,10 @@ final class RecordingManager: NSObject {
     }
 
     /// 녹화를 종료하고 파일을 저장합니다.
-    func stopRecording(completion: @escaping () -> Void) {
+    func stopRecording(completion: @escaping (String?) -> Void) {
         sessionQueue.async {
             guard let writer = self.writer, let input = self.writerInput else {
-                DispatchQueue.main.async { completion() }
+                DispatchQueue.main.async { completion(nil) }
                 return
             }
 
@@ -151,26 +151,28 @@ final class RecordingManager: NSObject {
                 self.writerInput = nil
                 self.startTime = nil
                 DispatchQueue.main.async {
-                    self.saveVideo(at: url)
-                    completion()
+                    self.saveVideo(at: url) { identifier in
+                        completion(identifier)
+                    }
                 }
             }
         }
     }
 
     /// 완성된 영상을 포토 라이브러리에 저장합니다.
-    private func saveVideo(at url: URL) {
-        DispatchQueue.main.async {
-            PHPhotoLibrary.shared().performChanges({
-                PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
-            }) { saved, error in
-                if let error = error {
-                    print("영상 저장 오류: \(error.localizedDescription)")
-                }
-                DispatchQueue.global(qos: .background).async {
-                    try? FileManager.default.removeItem(at: url)
-                }
+    private func saveVideo(at url: URL, completion: @escaping (String?) -> Void) {
+        var identifier: String?
+        PHPhotoLibrary.shared().performChanges({
+            let request = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
+            identifier = request.placeholderForCreatedAsset?.localIdentifier
+        }) { saved, error in
+            if let error {
+                print("영상 저장 오류: \(error.localizedDescription)")
             }
+            DispatchQueue.global(qos: .background).async {
+                try? FileManager.default.removeItem(at: url)
+            }
+            completion(saved ? identifier : nil)
         }
     }
 }

--- a/cruxx/Core/Recording/RecordingViewModel.swift
+++ b/cruxx/Core/Recording/RecordingViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import UIKit
+import CoreData
 
 /// 녹화 상태와 액션을 관리하는 뷰모델입니다.
 @MainActor
@@ -11,12 +12,7 @@ final class RecordingViewModel: ObservableObject {
     private let recordingManager = RecordingManager()
     private var elapsedTimer: Timer?
     private var backgroundObserver: NSObjectProtocol?
-
-    struct ClimbingSession {
-        let filename: String
-        let date: Date
-        let fileURL: URL
-    }
+    private let context = PersistenceController.shared.viewContext
 
     init() {
         backgroundObserver = NotificationCenter.default.addObserver(
@@ -82,14 +78,22 @@ final class RecordingViewModel: ObservableObject {
 
     /// 녹화를 종료합니다.
     func stopRecording() {
-        recordingManager.stopRecording { [weak self] in
+        recordingManager.stopRecording { [weak self] identifier in
             guard let self else { return }
             Task { @MainActor in
                 self.isRecording = false
                 self.stopElapsedTimer()
-                let url = FileManager.default.temporaryDirectory.appendingPathComponent("cruxx_temp.mov")
-                let session = ClimbingSession(filename: url.lastPathComponent, date: Date(), fileURL: url)
-                print("Saved session: \(session)")
+                if let id = identifier {
+                    let session = ClimbingSession(
+                        id: UUID(),
+                        filename: "\(id).mov",
+                        filePath: id,
+                        date: Date(),
+                        duration: self.elapsedTime
+                    )
+                    self.insertSession(session)
+                    print("Saved session: \(session)")
+                }
                 self.showSaveMessage = true
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
@@ -97,6 +101,21 @@ final class RecordingViewModel: ObservableObject {
                     self?.showSaveMessage = false
                 }
             }
+        }
+    }
+
+    /// Core Data에 세션을 저장합니다.
+    private func insertSession(_ session: ClimbingSession) {
+        let entity = NSEntityDescription.insertNewObject(forEntityName: "ClimbingSession", into: context)
+        entity.setValue(session.id, forKey: "id")
+        entity.setValue(session.filename, forKey: "filename")
+        entity.setValue(session.filePath, forKey: "filePath")
+        entity.setValue(session.date, forKey: "date")
+        entity.setValue(session.duration, forKey: "duration")
+        do {
+            try context.save()
+        } catch {
+            print("세션 저장 실패: \(error)")
         }
     }
 }

--- a/cruxx/Core/Session/SessionListViewModel.swift
+++ b/cruxx/Core/Session/SessionListViewModel.swift
@@ -1,33 +1,34 @@
 import Foundation
 import SwiftUI
+import CoreData
 
 /// 저장된 세션 목록을 관리하는 뷰모델입니다.
 @MainActor
 final class SessionListViewModel: ObservableObject {
-    /// 등반 세션 데이터 구조입니다.
-    struct ClimbingSession: Identifiable {
-        let id = UUID()
-        let filename: String
-        let date: Date
-        let fileURL: URL
-    }
-
     @Published private(set) var sessions: [ClimbingSession] = []
+    private let context = PersistenceController.shared.viewContext
 
     init() {
-        loadMockSessions()
+        loadSessions()
     }
 
-    /// 임시 목업 세션 데이터를 생성합니다.
-    private func loadMockSessions() {
-        let baseURL = FileManager.default.temporaryDirectory
-        sessions = (1...10).map { index in
-            let filename = "session_\(index).mov"
-            return ClimbingSession(
-                filename: filename,
-                date: Calendar.current.date(byAdding: .day, value: -index, to: Date()) ?? Date(),
-                fileURL: baseURL.appendingPathComponent(filename)
-            )
+    /// Core Data에서 세션 데이터를 불러옵니다.
+    func loadSessions() {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "ClimbingSession")
+        do {
+            let result = try context.fetch(request)
+            sessions = result.compactMap { object in
+                guard
+                    let id = object.value(forKey: "id") as? UUID,
+                    let filename = object.value(forKey: "filename") as? String,
+                    let filePath = object.value(forKey: "filePath") as? String,
+                    let date = object.value(forKey: "date") as? Date
+                else { return nil }
+                let duration = object.value(forKey: "duration") as? Double
+                return ClimbingSession(id: id, filename: filename, filePath: filePath, date: date, duration: duration)
+            }
+        } catch {
+            print("세션 로드 실패: \(error)")
         }
     }
 }

--- a/cruxx/Model/ClimbingSession.swift
+++ b/cruxx/Model/ClimbingSession.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// 등반 세션 정보를 나타내는 모델입니다.
+struct ClimbingSession: Identifiable {
+    let id: UUID
+    let filename: String
+    let filePath: String
+    let date: Date
+    let duration: Double?
+}

--- a/cruxx/cruxxApp.swift
+++ b/cruxx/cruxxApp.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 @main
 struct cruxxApp: App {
+    private let persistenceController = PersistenceController.shared
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(\.managedObjectContext, persistenceController.viewContext)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `PersistenceController` for Core Data stack
- define `ClimbingSession` model
- record sessions to Core Data after saving video
- load stored sessions in `SessionListViewModel`
- connect Core Data context to app environment

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68517fdbca488332abcba042a19f6b51