### PR TITLE
Restart preview after recording

### DIFF
--- a/cruxx/Core/Recording/RecordingManager.swift
+++ b/cruxx/Core/Recording/RecordingManager.swift
@@ -150,6 +150,8 @@ final class RecordingManager: NSObject {
                 self.writer = nil
                 self.writerInput = nil
                 self.startTime = nil
+                // 녹화 정리 후 프리뷰 재시작
+                self.startSession()
                 DispatchQueue.main.async {
                     self.saveVideo(at: url) { identifier in
                         completion(identifier)


### PR DESCRIPTION
## Summary
- 녹화 종료 후 `AVCaptureSession`이 정지된 상태로 남아 프리뷰가 멈추는 문제를 수정했습니다.
- `finishWriting` 완료 시점에 `startSession()`을 호출해 세션을 즉시 재시작하도록 변경했습니다.

## Testing
- `git status`로 변경 사항 확인

------
https://chatgpt.com/codex/tasks/task_e_68518aa6e378833292f74397a63687a1