### PR TITLE
Implement session save notification

### DIFF
--- a/cruxx/Core/Recording/RecordingViewModel.swift
+++ b/cruxx/Core/Recording/RecordingViewModel.swift
@@ -114,6 +114,7 @@ final class RecordingViewModel: ObservableObject {
         entity.setValue(session.duration, forKey: "duration")
         do {
             try context.save()
+            NotificationCenter.default.post(name: .didSaveClimbingSession, object: nil)
         } catch {
             print("세션 저장 실패: \(error)")
         }

--- a/cruxx/Core/Session/SessionListViewModel.swift
+++ b/cruxx/Core/Session/SessionListViewModel.swift
@@ -7,9 +7,23 @@ import CoreData
 final class SessionListViewModel: ObservableObject {
     @Published private(set) var sessions: [ClimbingSessionModel] = []
     private let context = PersistenceController.shared.viewContext
+    private var saveObserver: NSObjectProtocol?
 
     init() {
         loadSessions()
+        saveObserver = NotificationCenter.default.addObserver(
+            forName: .didSaveClimbingSession,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.loadSessions()
+        }
+    }
+
+    deinit {
+        if let saveObserver {
+            NotificationCenter.default.removeObserver(saveObserver)
+        }
     }
 
     /// Core Data에서 세션 데이터를 불러옵니다.

--- a/cruxx/Core/Utils/Notification+Extension.swift
+++ b/cruxx/Core/Utils/Notification+Extension.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Notification.Name {
+    static let didSaveClimbingSession = Notification.Name("didSaveClimbingSession")
+}


### PR DESCRIPTION
## Summary
- add `didSaveClimbingSession` notification
- post notification after saving a session
- observe notification in `SessionListViewModel` to refresh list

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_68518b718a6c8332abe16dca94520c23