### PR TITLE
store recorded videos in Documents/raw

### DIFF
--- a/cruxx/Core/Recording/RecordingManager.swift
+++ b/cruxx/Core/Recording/RecordingManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 import AVFoundation
-import Photos
+
 
 /// AVFoundation을 이용해 카메라 세션과 녹화를 관리합니다.
 final class RecordingManager: NSObject {
@@ -8,10 +8,17 @@ final class RecordingManager: NSObject {
     private let sessionQueue = DispatchQueue(label: "RecordingSessionQueue")
     private let videoOutput = AVCaptureVideoDataOutput()
     private let portraitDimensions = (width: 1080, height: 1920)
-    
+
     private var writer: AVAssetWriter?
     private var writerInput: AVAssetWriterInput?
     private var startTime: CMTime?
+    private var outputURL: URL?
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmm"
+        return formatter
+    }()
     
     var previewLayer: AVCaptureVideoPreviewLayer {
         let layer = AVCaptureVideoPreviewLayer(session: session)
@@ -98,8 +105,13 @@ final class RecordingManager: NSObject {
             self.videoOutput.setSampleBufferDelegate(nil, queue: nil)
             self.videoOutput.setSampleBufferDelegate(self, queue: self.sessionQueue)
             
-            let url = FileManager.default.temporaryDirectory.appendingPathComponent("cruxx_temp.mov")
+            let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            let rawDir = documents.appendingPathComponent("raw", isDirectory: true)
+            try? FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+            let timestamp = Self.dateFormatter.string(from: Date())
+            let url = rawDir.appendingPathComponent("session_\(timestamp).mov")
             try? FileManager.default.removeItem(at: url)
+            self.outputURL = url
             
             let assetWriter: AVAssetWriter
             do {
@@ -153,31 +165,12 @@ final class RecordingManager: NSObject {
                 // 녹화 정리 후 프리뷰 재시작
                 self.startSession()
                 DispatchQueue.main.async {
-                    self.saveVideo(at: url) { identifier in
-                        completion(identifier)
-                    }
+                    completion(url.path)
                 }
             }
         }
     }
-    
-    /// 완성된 영상을 포토 라이브러리에 저장합니다.
-    private func saveVideo(at url: URL, completion: @escaping (String?) -> Void) {
-        var identifier: String?
-        PHPhotoLibrary.shared().performChanges({
-            if let request = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url) {
-                identifier = request.placeholderForCreatedAsset?.localIdentifier
-            }
-        }) { saved, error in
-            if let error {
-                print("영상 저장 오류: \(error.localizedDescription)")
-            }
-            DispatchQueue.global(qos: .background).async {
-                try? FileManager.default.removeItem(at: url)
-            }
-            completion(saved ? identifier : nil)
-        }
-    }
+
 }
 
 extension RecordingManager: AVCaptureVideoDataOutputSampleBufferDelegate {

--- a/cruxx/Core/Recording/RecordingViewModel.swift
+++ b/cruxx/Core/Recording/RecordingViewModel.swift
@@ -78,16 +78,17 @@ final class RecordingViewModel: ObservableObject {
 
     /// 녹화를 종료합니다.
     func stopRecording() {
-        recordingManager.stopRecording { [weak self] identifier in
+        recordingManager.stopRecording { [weak self] path in
             guard let self else { return }
             Task { @MainActor in
                 self.isRecording = false
                 self.stopElapsedTimer()
-                if let id = identifier {
+                if let path {
+                    let url = URL(fileURLWithPath: path)
                     let session = ClimbingSessionModel(
                         id: UUID(),
-                        filename: "\(id).mov",
-                        filePath: id,
+                        filename: url.lastPathComponent,
+                        filePath: path,
                         date: Date(),
                         duration: self.elapsedTime
                     )


### PR DESCRIPTION
## Summary
- record 영상 파일을 Photos 대신 앱 Documents/raw 폴더에 저장
- 세션 저장 시 경로와 파일명을 Core Data 에 기록

## Testing
- `swift --version`
- `xcodebuild -list -project cruxx.xcodeproj` *(실패: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851904d85648332be1f0e6a2701c4aa