### PR TITLE
Implement thumbnail cache

### DIFF
--- a/cruxx/App/Features/Session/SessionListView.swift
+++ b/cruxx/App/Features/Session/SessionListView.swift
@@ -31,12 +31,10 @@ struct SessionListView: View {
 
 private struct SessionCard: View {
     let session: ClimbingSessionModel
-    private let thumbnail: UIImage?
+    @State private var thumbnail: UIImage?
 
     init(session: ClimbingSessionModel) {
         self.session = session
-        let url = URL(fileURLWithPath: session.filePath)
-        self.thumbnail = generateThumbnail(from: url)
     }
 
     var body: some View {
@@ -75,6 +73,20 @@ private struct SessionCard: View {
                 .stroke(Color.white.opacity(0.15), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.25), radius: 10, x: 0, y: 4)
+        .onAppear {
+            let key = session.id.uuidString
+            if let cached = ThumbnailCache.shared.get(for: key) {
+                thumbnail = cached
+            } else {
+                let url = URL(fileURLWithPath: session.filePath)
+                generateThumbnailAsync(from: url) { image in
+                    if let image {
+                        ThumbnailCache.shared.set(image, for: key)
+                        thumbnail = image
+                    }
+                }
+            }
+        }
     }
 
     private func dateString(from date: Date) -> String {
@@ -96,6 +108,16 @@ private func generateThumbnail(from url: URL) -> UIImage? {
     } catch {
         print("썸네일 생성 실패: \(error)")
         return nil
+    }
+}
+
+/// 비동기적으로 썸네일을 생성합니다.
+private func generateThumbnailAsync(from url: URL, completion: @escaping (UIImage?) -> Void) {
+    DispatchQueue.global(qos: .userInitiated).async {
+        let image = generateThumbnail(from: url)
+        DispatchQueue.main.async {
+            completion(image)
+        }
     }
 }
 

--- a/cruxx/Core/Utils/ThumbnailCache.swift
+++ b/cruxx/Core/Utils/ThumbnailCache.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+/// 메모리 기반 썸네일 캐시를 관리하는 싱글턴 클래스입니다.
+final class ThumbnailCache {
+    static let shared = ThumbnailCache()
+    private init() {}
+
+    private var cache: [String: UIImage] = [:]
+
+    /// 지정한 키에 해당하는 이미지를 반환합니다.
+    func get(for key: String) -> UIImage? {
+        return cache[key]
+    }
+
+    /// 이미지를 캐시에 저장합니다.
+    func set(_ image: UIImage, for key: String) {
+        cache[key] = image
+    }
+}


### PR DESCRIPTION
## Summary
- add memory cache utility
- load cached thumbnails in `SessionListView`
- generate thumbnails asynchronously if missing

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6851916c02b48332ba96929bd52dd0b3