### PR TITLE
Add long-press delete button

### DIFF
--- a/cruxx/App/Features/Session/SessionListView.swift
+++ b/cruxx/App/Features/Session/SessionListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Foundation
 import AVFoundation
 import UIKit
+import CoreData
 
 /// 저장된 세션 영상을 카드 형태로 나열하는 화면입니다.
 struct SessionListView: View {
@@ -21,6 +22,7 @@ struct SessionListView: View {
                 LazyVGrid(columns: columns, spacing: 16) {
                     ForEach(viewModel.sessions) { session in
                         SessionCard(session: session)
+                            .environmentObject(viewModel)
                     }
                 }
                 .padding()
@@ -32,47 +34,86 @@ struct SessionListView: View {
 private struct SessionCard: View {
     let session: ClimbingSessionModel
     @State private var thumbnail: UIImage?
+    @State private var isDeleteVisible = false
+    @State private var showDeleteAlert = false
+    @State private var hideTask: DispatchWorkItem?
+    @EnvironmentObject private var viewModel: SessionListViewModel
 
     init(session: ClimbingSessionModel) {
         self.session = session
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if let thumbnail {
-                Image(uiImage: thumbnail)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
+        ZStack(alignment: .topTrailing) {
+            VStack(alignment: .leading, spacing: 8) {
+                if let thumbnail {
+                    Image(uiImage: thumbnail)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(height: 180)
+                        .clipped()
+                } else {
+                    ZStack {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.3))
+                        Text("Preview unavailable")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.8))
+                    }
                     .frame(height: 180)
-                    .clipped()
-            } else {
-                ZStack {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                    Text("Preview unavailable")
-                        .font(.caption)
-                        .foregroundColor(.white.opacity(0.8))
                 }
-                .frame(height: 180)
+                Text(session.filename)
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                Text(dateString(from: session.date))
+                    .font(.subheadline)
+                    .foregroundColor(.white.opacity(0.7))
             }
-            Text(session.filename)
-                .font(.headline)
-                .foregroundColor(.white)
-                .lineLimit(1)
-            Text(dateString(from: session.date))
-                .font(.subheadline)
-                .foregroundColor(.white.opacity(0.7))
+            .padding(12)
+            .background(
+                .ultraThinMaterial,
+                in: RoundedRectangle(cornerRadius: 20)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(Color.white.opacity(0.15), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.25), radius: 10, x: 0, y: 4)
+
+            Button {
+                showDeleteAlert = true
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .foregroundColor(.white)
+                    .padding(8)
+                    .background(Color.black.opacity(0.5))
+                    .clipShape(Circle())
+            }
+            .opacity(isDeleteVisible ? 1 : 0)
+            .animation(.easeInOut, value: isDeleteVisible)
+            .transition(.opacity.combined(with: .scale))
         }
-        .padding(12)
-        .background(
-            .ultraThinMaterial,
-            in: RoundedRectangle(cornerRadius: 20)
+        .gesture(
+            LongPressGesture().onEnded { _ in
+                withAnimation {
+                    isDeleteVisible.toggle()
+                }
+                startHideTimer()
+            }
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 20)
-                .stroke(Color.white.opacity(0.15), lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.25), radius: 10, x: 0, y: 4)
+        .alert("세션을 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
+            Button("삭제", role: .destructive) { deleteSession() }
+            Button("취소", role: .cancel) {}
+        }
+        .onTapGesture {
+            if isDeleteVisible {
+                withAnimation { isDeleteVisible = false }
+                hideTask?.cancel()
+            }
+        }
         .onAppear {
             let key = session.id.uuidString
             if let cached = ThumbnailCache.shared.get(for: key) {
@@ -93,6 +134,28 @@ private struct SessionCard: View {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         return formatter.string(from: date)
+    }
+
+    private func startHideTimer() {
+        hideTask?.cancel()
+        let task = DispatchWorkItem {
+            withAnimation { isDeleteVisible = false }
+        }
+        hideTask = task
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: task)
+    }
+
+    private func deleteSession() {
+        let context = PersistenceController.shared.viewContext
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "ClimbingSession")
+        request.predicate = NSPredicate(format: "id == %@", session.id as CVarArg)
+        if let results = try? context.fetch(request), let object = results.first as? NSManagedObject {
+            context.delete(object)
+            try? context.save()
+        }
+        let url = URL(fileURLWithPath: session.filePath)
+        try? FileManager.default.removeItem(at: url)
+        viewModel.loadSessions()
     }
 }
 


### PR DESCRIPTION
## Summary
- 세션 카드를 길게 눌러 삭제 버튼을 표시하도록 UI 개선
- 삭제 버튼을 누르면 Core Data와 파일을 삭제 후 목록을 갱신

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_6851922ee6548332963e2c03e612121a