### PR TITLE
Add session detail view

### DIFF
--- a/cruxx/App/Features/Session/SessionDetailView.swift
+++ b/cruxx/App/Features/Session/SessionDetailView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+import AVKit
+
+/// 선택한 등반 세션의 영상을 재생하며 정보를 보여주는 화면입니다.
+struct SessionDetailView: View {
+    let session: ClimbingSessionModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var player: AVPlayer?
+
+    var body: some View {
+        ZStack {
+            if let player {
+                VideoPlayer(player: player)
+                    .ignoresSafeArea()
+            } else {
+                Color.black.ignoresSafeArea()
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Spacer()
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(session.filename)
+                        .font(.headline)
+                        .foregroundColor(.white)
+                    Text(dateString(from: session.date))
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.8))
+                    if let duration = session.duration {
+                        Text(timeString(from: duration))
+                            .font(.subheadline)
+                            .foregroundColor(.white.opacity(0.8))
+                    }
+                }
+                .padding(16)
+                .background(
+                    .ultraThinMaterial,
+                    in: RoundedRectangle(cornerRadius: 20)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.white.opacity(0.15), lineWidth: 1)
+                )
+                .padding()
+            }
+
+            HStack {
+                Spacer()
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                        .foregroundColor(.white)
+                        .padding(10)
+                        .background(Color.black.opacity(0.5))
+                        .clipShape(Circle())
+                }
+                .padding()
+            }
+        }
+        .onAppear {
+            let url = URL(fileURLWithPath: session.filePath)
+            player = AVPlayer(url: url)
+            player?.play()
+        }
+        .onDisappear {
+            player?.pause()
+        }
+    }
+
+    private func dateString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private func timeString(from time: TimeInterval) -> String {
+        let minutes = Int(time) / 60
+        let seconds = Int(time) % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}
+
+#Preview {
+    let sample = ClimbingSessionModel(
+        id: UUID(),
+        filename: "Sample.mov",
+        filePath: "/path/to/sample.mov",
+        date: Date(),
+        duration: 65
+    )
+    return SessionDetailView(session: sample)
+}

--- a/cruxx/App/Features/Session/SessionListView.swift
+++ b/cruxx/App/Features/Session/SessionListView.swift
@@ -13,20 +13,23 @@ struct SessionListView: View {
     ]
 
     var body: some View {
-        ScrollView {
-            if viewModel.sessions.isEmpty {
-                Text("No sessions saved yet.")
-                    .foregroundColor(.white.opacity(0.7))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                LazyVGrid(columns: columns, spacing: 16) {
-                    ForEach(viewModel.sessions) { session in
-                        SessionCard(session: session)
-                            .environmentObject(viewModel)
+        NavigationStack {
+            ScrollView {
+                if viewModel.sessions.isEmpty {
+                    Text("No sessions saved yet.")
+                        .foregroundColor(.white.opacity(0.7))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    LazyVGrid(columns: columns, spacing: 16) {
+                        ForEach(viewModel.sessions) { session in
+                            SessionCard(session: session)
+                                .environmentObject(viewModel)
+                        }
                     }
+                    .padding()
                 }
-                .padding()
             }
+            .navigationTitle("Sessions")
         }
     }
 }
@@ -44,12 +47,15 @@ private struct SessionCard: View {
     }
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            VStack(alignment: .leading, spacing: 8) {
-                if let thumbnail {
-                    Image(uiImage: thumbnail)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
+        NavigationLink {
+            SessionDetailView(session: session)
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let thumbnail {
+                        Image(uiImage: thumbnail)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
                         .frame(height: 180)
                         .clipped()
                 } else {
@@ -90,12 +96,14 @@ private struct SessionCard: View {
                     .foregroundColor(.white)
                     .padding(8)
                     .background(Color.black.opacity(0.5))
-                    .clipShape(Circle())
+                        .clipShape(Circle())
+                }
+                .opacity(isDeleteVisible ? 1 : 0)
+                .animation(.easeInOut, value: isDeleteVisible)
+                .transition(.opacity.combined(with: .scale))
             }
-            .opacity(isDeleteVisible ? 1 : 0)
-            .animation(.easeInOut, value: isDeleteVisible)
-            .transition(.opacity.combined(with: .scale))
         }
+        .buttonStyle(.plain)
         .gesture(
             LongPressGesture().onEnded { _ in
                 withAnimation {
@@ -107,12 +115,6 @@ private struct SessionCard: View {
         .alert("세션을 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
             Button("삭제", role: .destructive) { deleteSession() }
             Button("취소", role: .cancel) {}
-        }
-        .onTapGesture {
-            if isDeleteVisible {
-                withAnimation { isDeleteVisible = false }
-                hideTask?.cancel()
-            }
         }
         .onAppear {
             let key = session.id.uuidString


### PR DESCRIPTION
## Summary
- show list in a navigation stack
- connect each session card to a new `SessionDetailView`
- create `SessionDetailView` for video playback and metadata

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851948afaf08332b15630200b1d5f13