### PR TITLE
Apply user recording settings

### DIFF
--- a/cruxx/App/Features/Recording/RecordingView.swift
+++ b/cruxx/App/Features/Recording/RecordingView.swift
@@ -4,10 +4,20 @@ import AVFoundation
 /// 라이브 카메라 프리뷰와 녹화 버튼을 제공하는 화면입니다.
 struct RecordingView: View {
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var viewModel = RecordingViewModel()
-    @State private var countdown: Int?
-    @State private var countdownTimer: Timer?
+    @AppStorage("includeMic") private var includeMic = true
+    @AppStorage("countdownSeconds") private var countdownSeconds = 3
+    @AppStorage("autoAnalyze") private var autoAnalyze = true
+
+    @StateObject private var viewModel: RecordingViewModel
     @State private var blink = false
+
+    init() {
+        _viewModel = StateObject(wrappedValue: RecordingViewModel(
+            includeMic: includeMic,
+            countdownSeconds: countdownSeconds,
+            autoAnalyze: autoAnalyze
+        ))
+    }
 
     var body: some View {
         ZStack {
@@ -66,8 +76,8 @@ struct RecordingView: View {
                 Button(action: {
                     if viewModel.isRecording {
                         viewModel.stopRecording()
-                    } else if countdown == nil {
-                        startCountdown()
+                    } else if viewModel.countdown == nil {
+                        viewModel.startRecording()
                     }
                 }) {
                     Circle()
@@ -79,12 +89,12 @@ struct RecordingView: View {
                         )
                         .shadow(color: .black.opacity(0.25), radius: 10, x: 0, y: 4)
                 }
-                .disabled(countdown != nil)
+                .disabled(viewModel.countdown != nil)
                 .padding(.bottom, 40)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
 
-            if let remaining = countdown {
+            if let remaining = viewModel.countdown {
                 Text("\(remaining)")
                     .font(.system(size: 60, weight: .bold))
                     .foregroundColor(.white)
@@ -123,23 +133,6 @@ struct RecordingView: View {
         }
         .onDisappear {
             viewModel.stopSession()
-        }
-    }
-
-    private func startCountdown() {
-        countdown = 3
-        countdownTimer?.invalidate()
-        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-            guard let current = countdown else { return }
-            if current > 1 {
-                countdown = current - 1
-            } else {
-                timer.invalidate()
-                countdown = nil
-                Task { @MainActor in
-                    viewModel.startRecording()
-                }
-            }
         }
     }
 

--- a/cruxx/Core/Recording/RecordingManager.swift
+++ b/cruxx/Core/Recording/RecordingManager.swift
@@ -5,6 +5,7 @@ import AVFoundation
 /// AVFoundation을 이용해 카메라 세션과 녹화를 관리합니다.
 final class RecordingManager: NSObject {
     let session = AVCaptureSession()
+    private let includeMic: Bool
     private let sessionQueue = DispatchQueue(label: "RecordingSessionQueue")
     private let videoOutput = AVCaptureVideoDataOutput()
     private let audioOutput = AVCaptureAudioDataOutput()
@@ -37,7 +38,8 @@ final class RecordingManager: NSObject {
         return layer
     }
     
-    override init() {
+    init(includeMic: Bool) {
+        self.includeMic = includeMic
         super.init()
         configureSession()
     }
@@ -59,7 +61,8 @@ final class RecordingManager: NSObject {
         session.addInput(input)
 
         // 마이크 입력을 세션에 추가합니다.
-        if let audioDevice = AVCaptureDevice.default(for: .audio),
+        if includeMic,
+           let audioDevice = AVCaptureDevice.default(for: .audio),
            let audioInput = try? AVCaptureDeviceInput(device: audioDevice),
            session.canAddInput(audioInput) {
             session.addInput(audioInput)
@@ -70,7 +73,7 @@ final class RecordingManager: NSObject {
             session.addOutput(videoOutput)
         }
 
-        if session.canAddOutput(audioOutput) {
+        if includeMic, session.canAddOutput(audioOutput) {
             audioOutput.setSampleBufferDelegate(self, queue: sessionQueue)
             session.addOutput(audioOutput)
         }
@@ -90,8 +93,10 @@ final class RecordingManager: NSObject {
     
     /// 카메라 세션을 시작합니다.
     func startSession() {
-        // 마이크 권한을 요청합니다.
-        AVCaptureDevice.requestAccess(for: .audio) { _ in }
+        // 마이크 입력을 사용할 경우 권한을 요청합니다.
+        if includeMic {
+            AVCaptureDevice.requestAccess(for: .audio) { _ in }
+        }
         sessionQueue.async {
             if !self.session.isRunning {
                 self.session.startRunning()
@@ -121,8 +126,10 @@ final class RecordingManager: NSObject {
 
             self.videoOutput.setSampleBufferDelegate(nil, queue: nil)
             self.videoOutput.setSampleBufferDelegate(self, queue: self.sessionQueue)
-            self.audioOutput.setSampleBufferDelegate(nil, queue: nil)
-            self.audioOutput.setSampleBufferDelegate(self, queue: self.sessionQueue)
+            if self.includeMic {
+                self.audioOutput.setSampleBufferDelegate(nil, queue: nil)
+                self.audioOutput.setSampleBufferDelegate(self, queue: self.sessionQueue)
+            }
             
             let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             let rawDir = documents.appendingPathComponent("raw", isDirectory: true)
@@ -155,17 +162,19 @@ final class RecordingManager: NSObject {
                 self.writerInput = input
             }
 
-            let audioSettings: [String: Any] = [
-                AVFormatIDKey: kAudioFormatMPEG4AAC,
-                AVNumberOfChannelsKey: 1,
-                AVSampleRateKey: 44100,
-                AVEncoderBitRateKey: 64000
-            ]
-            let audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
-            audioInput.expectsMediaDataInRealTime = true
-            if assetWriter.canAdd(audioInput) {
-                assetWriter.add(audioInput)
-                self.writerAudioInput = audioInput
+            if self.includeMic {
+                let audioSettings: [String: Any] = [
+                    AVFormatIDKey: kAudioFormatMPEG4AAC,
+                    AVNumberOfChannelsKey: 1,
+                    AVSampleRateKey: 44100,
+                    AVEncoderBitRateKey: 64000
+                ]
+                let audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+                audioInput.expectsMediaDataInRealTime = true
+                if assetWriter.canAdd(audioInput) {
+                    assetWriter.add(audioInput)
+                    self.writerAudioInput = audioInput
+                }
             }
             
             self.startTime = nil
@@ -183,9 +192,13 @@ final class RecordingManager: NSObject {
             }
 
             input.markAsFinished()
-            self.writerAudioInput?.markAsFinished()
+            if self.includeMic {
+                self.writerAudioInput?.markAsFinished()
+            }
             self.videoOutput.setSampleBufferDelegate(nil, queue: nil)
-            self.audioOutput.setSampleBufferDelegate(nil, queue: nil)
+            if self.includeMic {
+                self.audioOutput.setSampleBufferDelegate(nil, queue: nil)
+            }
             
             if self.session.isRunning {
                 self.session.stopRunning()
@@ -196,7 +209,9 @@ final class RecordingManager: NSObject {
                 let url = writer.outputURL
                 self.writer = nil
                 self.writerInput = nil
-                self.writerAudioInput = nil
+                if self.includeMic {
+                    self.writerAudioInput = nil
+                }
                 self.startTime = nil
                 // 녹화 정리 후 프리뷰 재시작
                 self.startSession()
@@ -212,7 +227,8 @@ final class RecordingManager: NSObject {
 extension RecordingManager: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate {
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         if output is AVCaptureAudioDataOutput {
-            guard let writer = writer,
+            guard includeMic,
+                  let writer = writer,
                   writer.status == .writing,
                   let input = writerAudioInput,
                   input.isReadyForMoreMediaData else { return }

--- a/cruxx/Core/Recording/RecordingViewModel.swift
+++ b/cruxx/Core/Recording/RecordingViewModel.swift
@@ -9,12 +9,24 @@ final class RecordingViewModel: ObservableObject {
     @Published private(set) var isRecording: Bool = false
     @Published var elapsedTime: TimeInterval = 0
     @Published var showSaveMessage: Bool = false
-    private let recordingManager = RecordingManager()
+    @Published var countdown: Int?
+
+    private let includeMic: Bool
+    private let countdownSeconds: Int
+    private let autoAnalyze: Bool
+
+    private let recordingManager: RecordingManager
     private var elapsedTimer: Timer?
+    private var countdownTimer: Timer?
     private var backgroundObserver: NSObjectProtocol?
     private let context = PersistenceController.shared.viewContext
 
-    init() {
+    init(includeMic: Bool, countdownSeconds: Int, autoAnalyze: Bool) {
+        self.includeMic = includeMic
+        self.countdownSeconds = countdownSeconds
+        self.autoAnalyze = autoAnalyze
+        self.recordingManager = RecordingManager(includeMic: includeMic)
+
         backgroundObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.willResignActiveNotification,
             object: nil,
@@ -33,6 +45,7 @@ final class RecordingViewModel: ObservableObject {
         if let observer = backgroundObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        countdownTimer?.invalidate()
     }
 
     private func startElapsedTimer() {
@@ -69,8 +82,31 @@ final class RecordingViewModel: ObservableObject {
         recordingManager.stopSession()
     }
 
-    /// 녹화를 시작합니다.
+    /// 녹화를 시작합니다. 카운트다운이 설정된 경우 카운트다운 후 시작합니다.
     func startRecording() {
+        if countdownSeconds > 0 {
+            countdown = countdownSeconds
+            countdownTimer?.invalidate()
+            countdownTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] timer in
+                guard let self else { return }
+                Task { @MainActor in
+                    guard let remaining = self.countdown else { return }
+                    if remaining > 1 {
+                        self.countdown = remaining - 1
+                    } else {
+                        timer.invalidate()
+                        self.countdown = nil
+                        self.startActualRecording()
+                    }
+                }
+            }
+        } else {
+            startActualRecording()
+        }
+    }
+
+    /// 실제 녹화 로직을 수행합니다.
+    private func startActualRecording() {
         recordingManager.startRecording()
         isRecording = true
         startElapsedTimer()
@@ -78,6 +114,8 @@ final class RecordingViewModel: ObservableObject {
 
     /// 녹화를 종료합니다.
     func stopRecording() {
+        countdownTimer?.invalidate()
+        countdownTimer = nil
         recordingManager.stopRecording { [weak self] path in
             guard let self else { return }
             Task { @MainActor in
@@ -94,6 +132,9 @@ final class RecordingViewModel: ObservableObject {
                     )
                     self.insertSession(session)
                     print("Saved session: \(session)")
+                    if self.autoAnalyze {
+                        self.runAutoAnalyze(url: url)
+                    }
                 }
                 self.showSaveMessage = true
             }
@@ -119,5 +160,11 @@ final class RecordingViewModel: ObservableObject {
         } catch {
             print("세션 저장 실패: \(error)")
         }
+    }
+
+    /// 녹화 파일에 대해 자동 분석을 실행합니다. 실제 분석 로직은 추후 구현됩니다.
+    private func runAutoAnalyze(url: URL) {
+        // TODO: PoseAnalyzer 연동 예정
+        print("자동 분석 시작: \(url.lastPathComponent)")
     }
 }


### PR DESCRIPTION
## Summary
- pass `includeMic`, `countdownSeconds`, `autoAnalyze` to `RecordingViewModel`
- propagate mic setting to `RecordingManager`
- manage countdown inside `RecordingViewModel`
- read user defaults with `@AppStorage` in `RecordingView`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685199a9c3408332899e61a3c914c9cb