### PR TITLE
Fix RecordingViewModel init and property name

### DIFF
--- a/cruxx/Core/Recording/RecordingViewModel.swift
+++ b/cruxx/Core/Recording/RecordingViewModel.swift
@@ -13,7 +13,7 @@ final class RecordingViewModel: ObservableObject {
 
     private let includeMic: Bool
     private let countdownSeconds: Int
-    private let autoAnalyze: Bool
+    private let autoAnalyzeAfterRecording: Bool
 
     private let recordingManager: RecordingManager
     private var elapsedTimer: Timer?
@@ -24,7 +24,7 @@ final class RecordingViewModel: ObservableObject {
     init(includeMic: Bool, countdownSeconds: Int, autoAnalyze: Bool) {
         self.includeMic = includeMic
         self.countdownSeconds = countdownSeconds
-        self.autoAnalyze = autoAnalyze
+        self.autoAnalyzeAfterRecording = autoAnalyze
         self.recordingManager = RecordingManager(includeMic: includeMic)
 
         backgroundObserver = NotificationCenter.default.addObserver(
@@ -132,7 +132,7 @@ final class RecordingViewModel: ObservableObject {
                     )
                     self.insertSession(session)
                     print("Saved session: \(session)")
-                    if self.autoAnalyze {
+                    if self.autoAnalyzeAfterRecording {
                         self.runAutoAnalyze(url: url)
                     }
                 }


### PR DESCRIPTION
## Summary
- update RecordingViewModel property name to avoid shadowing
- pass autoAnalyze parameter to new property and trigger analysis correctly

## Testing
- `xcodebuild -list -project cruxx/cruxx.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e096aaa883328ba9ef71ac3f95c8