### PR TITLE
Add video import feature

### DIFF
--- a/cruxx/App/Features/Session/SessionListView.swift
+++ b/cruxx/App/Features/Session/SessionListView.swift
@@ -7,6 +7,7 @@ import CoreData
 /// 저장된 세션 영상을 카드 형태로 나열하는 화면입니다.
 struct SessionListView: View {
     @StateObject private var viewModel = SessionListViewModel()
+    @State private var showPicker = false
     private let columns = [
         GridItem(.flexible(), spacing: 16),
         GridItem(.flexible())
@@ -30,6 +31,20 @@ struct SessionListView: View {
                 }
             }
             .navigationTitle("Sessions")
+            .sheet(isPresented: $showPicker) {
+                VideoPickerView { url in
+                    viewModel.importVideo(from: url)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showPicker = true
+                    } label: {
+                        Image(systemName: "square.and.arrow.down")
+                    }
+                }
+            }
         }
     }
 }

--- a/cruxx/App/Features/Session/VideoPickerView.swift
+++ b/cruxx/App/Features/Session/VideoPickerView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import PhotosUI
+
+/// PHPickerViewController를 래핑하여 비디오 선택을 처리합니다.
+struct VideoPickerView: UIViewControllerRepresentable {
+    var onPick: (URL) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPick: onPick)
+    }
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .videos
+        config.selectionLimit = 1
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        var onPick: (URL) -> Void
+
+        init(onPick: @escaping (URL) -> Void) {
+            self.onPick = onPick
+        }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+
+            guard let provider = results.first?.itemProvider,
+                  provider.hasItemConformingToTypeIdentifier("public.movie") else { return }
+
+            provider.loadFileRepresentation(forTypeIdentifier: "public.movie") { url, _ in
+                guard let srcURL = url else { return }
+
+                let fileManager = FileManager.default
+                let targetURL = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".mov")
+                try? fileManager.copyItem(at: srcURL, to: targetURL)
+
+                DispatchQueue.main.async {
+                    self.onPick(targetURL)
+                }
+            }
+        }
+    }
+}

--- a/cruxx/Core/Session/SessionListViewModel.swift
+++ b/cruxx/Core/Session/SessionListViewModel.swift
@@ -54,5 +54,54 @@ final class SessionListViewModel: ObservableObject {
             print("세션 로드 실패: \(error)")
         }
     }
+
+    /// 선택한 비디오 파일을 앱의 세션으로 등록합니다.
+    func importVideo(from url: URL) {
+        let fileManager = FileManager.default
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let rawDir = documents.appendingPathComponent("raw", isDirectory: true)
+        try? fileManager.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        let targetURL = rawDir.appendingPathComponent("session_\(UUID().uuidString).mov")
+        do {
+            try fileManager.copyItem(at: url, to: targetURL)
+        } catch {
+            print("비디오 복사 실패: \(error)")
+        }
+
+        let session = ClimbingSessionModel(
+            id: UUID(),
+            filename: targetURL.lastPathComponent,
+            filePath: targetURL.path,
+            date: Date(),
+            duration: nil
+        )
+        insertSession(session)
+
+        if UserDefaults.standard.bool(forKey: "autoAnalyze") {
+            runAutoAnalyze(url: targetURL)
+        }
+    }
+
+    /// Core Data에 세션을 저장합니다.
+    private func insertSession(_ session: ClimbingSessionModel) {
+        let entity = NSEntityDescription.insertNewObject(forEntityName: "ClimbingSession", into: context)
+        entity.setValue(session.id, forKey: "id")
+        entity.setValue(session.filename, forKey: "filename")
+        entity.setValue(session.filePath, forKey: "filePath")
+        entity.setValue(session.date, forKey: "date")
+        entity.setValue(session.duration, forKey: "duration")
+        do {
+            try context.save()
+            NotificationCenter.default.post(name: .didSaveClimbingSession, object: nil)
+        } catch {
+            print("세션 저장 실패: \(error)")
+        }
+    }
+
+    /// 비디오 분석을 자동으로 실행합니다.
+    private func runAutoAnalyze(url: URL) {
+        // TODO: PoseAnalyzer 연동 예정
+        print("자동 분석 시작: \(url.lastPathComponent)")
+    }
 }
 


### PR DESCRIPTION
## Summary
- 사용자가 포토 라이브러리에서 기존 비디오를 선택해 세션으로 등록할 수 있도록 기능 추가
- SessionListView에 비디오 가져오기 버튼 및 시트 구현
- VideoPickerView를 새로 작성하여 PHPickerViewController 래핑
- SessionListViewModel에 importVideo 메서드 추가

## Testing
- `swift --version` 실행

------
https://chatgpt.com/codex/tasks/task_e_6862942afaec83328adcda4b9f697658